### PR TITLE
#41: non-admin users can only view their own role applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Web services for Dancesport Application System (DAS).
 [![GoDoc](https://godoc.org/github.com/DancesportSoftware/das?status.svg)](https://godoc.org/github.com/DancesportSoftware/das)
 [![Build Status](https://travis-ci.org/DancesportSoftware/das.svg?branch=master)](https://travis-ci.org/DancesportSoftware/das)
 [![codecov](https://codecov.io/gh/DancesportSoftware/das/branch/development/graph/badge.svg)](https://codecov.io/gh/DancesportSoftware/das)
+[![codebeat badge](https://codebeat.co/badges/760a6628-dd44-4e33-af98-c195bc85fd20)](https://codebeat.co/projects/github-com-dancesportsoftware-das-master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/76bb2da0aa0e4a2486365500d3f93e8f)](https://www.codacy.com/app/DancesportSoftware/das_2?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=DancesportSoftware/das&amp;utm_campaign=Badge_Grade)
 [![Go Report Card](https://goreportcard.com/badge/github.com/DancesportSoftware/das)](https://goreportcard.com/report/github.com/DancesportSoftware/das)
 

--- a/config/routes/internal/account/role.go
+++ b/config/routes/internal/account/role.go
@@ -12,7 +12,12 @@ import (
 const apiAccountRoleCreateApplication = "/api/v1.0/account/role/application"
 const apiAccountRoleRespondApplication = "/api/v1.0/account/role/provision" // Admin use only
 
-var roleProvisionService = businesslogic.NewRoleProvisionService(database.AccountRepository, database.RoleApplicationRepository, database.AccountRoleRepository)
+var roleProvisionService = businesslogic.NewRoleProvisionService(
+	database.AccountRepository,
+	database.RoleApplicationRepository,
+	database.AccountRoleRepository,
+	database.OrganizerProvisionRepository,
+	database.OrganizerProvisionHistoryRepository)
 var roleApplicationServer = account.NewRoleApplicationServer(middleware.AuthenticationStrategy, *roleProvisionService)
 
 var createRoleApplicationController = util.DasController{
@@ -22,12 +27,7 @@ var createRoleApplicationController = util.DasController{
 	Endpoint:    apiAccountRoleCreateApplication,
 	Handler:     roleApplicationServer.CreateRoleApplicationHandler,
 	AllowedRoles: []int{
-		businesslogic.AccountTypeAthlete,
-		businesslogic.AccountTypeAdjudicator,
-		businesslogic.AccountTypeScrutineer,
-		businesslogic.AccountTypeOrganizer,
-		businesslogic.AccountTypeDeckCaptain,
-		businesslogic.AccountTypeEmcee,
+		businesslogic.AccountTypeAthlete, // 2018-12-12: all users have athlete role and are granted to apply for other roles
 	},
 }
 

--- a/viewmodel/provision.go
+++ b/viewmodel/provision.go
@@ -54,7 +54,7 @@ type RoleApplication struct {
 	ID                int       `json:"id"`
 	ApplicantName     string    `json:"applicant"`
 	RoleApplied       int       `json:"role"`
-	Description       string    `json:"description "`
+	Description       string    `json:"description"`
 	Status            int       `json:"status"`
 	DateTimeSubmitted time.Time `json:"created"`
 	DateTimeResponded time.Time `json:"responded"`


### PR DESCRIPTION
Refactored RoleProvisionService:
- Approving Organizer role application will trigger the creation of Organizer Competition Provision records
- Enforce Role Application Search to search applications that are made by the current user if the current user is not an Admin
- Fixed an issue with the JSON field in RoleApplication